### PR TITLE
Fix redirects for nested routes in Next.js config

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -18,47 +18,47 @@ const nextConfig: NextConfig = {
     return [
       // Redirect common app paths to waitlist
       {
-        source: '/app',
+        source: '/app/:path*',
         destination: '/',
         permanent: false,
       },
       {
-        source: '/dashboard',
+        source: '/dashboard/:path*',
         destination: '/',
         permanent: false,
       },
       {
-        source: '/account',
+        source: '/account/:path*',
         destination: '/',
         permanent: false,
       },
       {
-        source: '/login',
+        source: '/login/:path*',
         destination: '/',
         permanent: false,
       },
       {
-        source: '/signup',
+        source: '/signup/:path*',
         destination: '/',
         permanent: false,
       },
       {
-        source: '/quiz',
+        source: '/quiz/:path*',
         destination: '/',
         permanent: false,
       },
       {
-        source: '/products',
+        source: '/products/:path*',
         destination: '/',
         permanent: false,
       },
       {
-        source: '/cart',
+        source: '/cart/:path*',
         destination: '/',
         permanent: false,
       },
       {
-        source: '/checkout',
+        source: '/checkout/:path*',
         destination: '/',
         permanent: false,
       }


### PR DESCRIPTION
## Summary
- redirect nested paths like `/app/*` and `/dashboard/*` back to the waitlist

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch Poppins & Urbanist fonts)*

------
https://chatgpt.com/codex/tasks/task_e_689e0768ce288325a0356ce28b8c22d7